### PR TITLE
add FCM sender_id

### DIFF
--- a/service-worker/manifests/manifest.de.json
+++ b/service-worker/manifests/manifest.de.json
@@ -18,5 +18,6 @@
         }
     ],
     "theme_color": "#fff",
-    "background_color": "#fff"
+    "background_color": "#fff",
+    "gcm_sender_id": "103953800507"
 }


### PR DESCRIPTION
Despite of clients already receiving web push notifications, that change is required by FCM documentation: https://firebase.google.com/docs/cloud-messaging/js/client#configure_the_browser_to_receive_messages