### PR TITLE
add gcm_sender_id

### DIFF
--- a/service-worker/manifests/manifest.json
+++ b/service-worker/manifests/manifest.json
@@ -17,5 +17,6 @@
         }
     ],
     "theme_color": "#fff",
-    "background_color": "#fff"
+    "background_color": "#fff",
+    "gcm_sender_id": "103953800507"
 }


### PR DESCRIPTION
previous attempt to add `gcm_sender_id` make to difference since the only `manifest.json` file is the one which loaded on list page